### PR TITLE
Add normalization functionality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,13 @@ jobs:
     - name: Kraken
       run: |
         snakemake --use-conda -j 4 --configfile .test/config/kraken.yaml -p results/kraken/sample1_1_pe.kreport results/kraken/sample4_1_se.kreport
-    - name: Metaspades
+    - name: Metaspades + RGI
       run: |
         snakemake --use-conda -j 4 --configfile .test/config/metaspades.yaml -p assemble
         rm -r results/assembly results/report examples/data/sample*
+    - name: RGI
+      run: |
+        snakemake --use-conda -j 4 --configfile .test/config/metaspades.yaml -p annotate
     - name: Prepare taxonomy
       run: bash .test/scripts/prep_taxonomy.sh
     - name: Taxonomy

--- a/.test/config/metaspades.yaml
+++ b/.test/config/metaspades.yaml
@@ -117,13 +117,13 @@ annotation:
   # run tRNAscan-SE?
   tRNAscan: False
   # run infernal for rRNA identification?
-  infernal: True
+  infernal: False
   # run eggnog-mapper to infer KEGG orthologs, pathways and modules?
   eggnog: False
   # run PFAM-scan to infer protein families from PFAM?
-  pfam: True
+  pfam: False
   # run Resistance gene identifier?
-  rgi: False
+  rgi: True
   # run taxonomic annotation of assembled contigs (using tango + sourmash)?
   taxonomy: False
 

--- a/workflow/envs/normalize.yml
+++ b/workflow/envs/normalize.yml
@@ -1,0 +1,8 @@
+name: normalize
+channels:
+  - r
+  - bioconda
+  - defaults
+dependencies:
+  - bioconductor-edger=3.30.0
+  - bioconductor-metagenomeseq=1.30.0

--- a/workflow/envs/rgi.yml
+++ b/workflow/envs/rgi.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - rgi=4.0.3
+  - rgi=5.1.1

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -411,6 +411,7 @@ rule rgi:
     params:
         out=opj(config["paths"]["results"], "annotation", "{assembly}", "rgi.out"),
         settings="-a diamond --local --clean --input_type protein"
+    shadow: "minimal"
     conda:
         "../envs/rgi.yml"
     threads: 10
@@ -418,7 +419,15 @@ rule rgi:
         runtime=lambda wildcards, attempt: attempt**2*60
     shell:
         """
-        rgi load --card_json {input.db} --local > {log} 2>&1
+        rgi load -i {input.db} --local > {log} 2>&1
         rgi main -i {input.faa} -o {params.out} \
             -n {threads} {params.settings} >>{log} 2>>{log}
         """
+
+rule parse_rgi:
+    input:
+        txt=opj(config["paths"]["results"], "annotation", "{assembly}", "rgi.out.txt")
+    output:
+        tsv=opj(config["paths"]["results"], "annotation", "{assembly}", "rgi.parsed.tsv")
+    script:
+        "../scripts/annotation_utils.py"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -37,7 +37,7 @@ wildcard_constraints:
     group="\w+",
     l="\d+",
     counts_type="(counts|rpkm)",
-    norm_method="(TMM|CSS|REL)"
+    norm_method="(TMM|CSS|RLE)"
 
 from scripts.common import check_uppmax, check_annotation, check_assembly, check_classifiers
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -35,7 +35,8 @@ wildcard_constraints:
     seq_type="[sp]e",
     binner="[a-z]+",
     group="\w+",
-    l="\d+"
+    l="\d+",
+    norm_method="(TMM|CSS|REL)"
 
 from scripts.common import check_uppmax, check_annotation, check_assembly, check_classifiers
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -36,6 +36,7 @@ wildcard_constraints:
     binner="[a-z]+",
     group="\w+",
     l="\d+",
+    counts_type="(counts|rpkm)",
     norm_method="(TMM|CSS|REL)"
 
 from scripts.common import check_uppmax, check_annotation, check_assembly, check_classifiers

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -91,7 +91,7 @@ rule featurecount:
     threads: 4
     params:
         tmpdir=config["paths"]["temp"],
-        setting=lambda wildcards: "-B -p" if wildcards.seq_type == "pe" else ""
+        setting=lambda wildcards: "-Q 10 -B -p" if wildcards.seq_type == "pe" else ""
     resources:
         runtime=lambda wildcards, attempt: attempt**2*30
     conda:

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -142,6 +142,9 @@ rule rpkm:
         "../scripts/normalize.R"
 
 rule count_features:
+    """
+    Sums read counts for gene annotation features such as pfam, KOs etc.
+    """
     input:
         abund=opj(config["paths"]["results"], "annotation", "{assembly}", "gene_counts.tsv"),
         annot=opj(config["paths"]["results"], "annotation", "{assembly}", "{db}.parsed.tsv")
@@ -151,6 +154,9 @@ rule count_features:
         "../scripts/quantification_utils.py"
 
 rule normalize_features:
+    """
+    Normalizes counts of features using TMM, REL or CSS
+    """
     input:
         opj(config["paths"]["results"], "annotation", "{assembly}", "{db}.parsed.counts.tsv")
     output:
@@ -165,6 +171,9 @@ rule normalize_features:
         "../scripts/normalize.R"
 
 rule sum_to_taxa:
+    """
+    Sums read counts and RPKM values for genes to assigned taxonomy
+    """
     input:
         tax=opj(config["paths"]["results"], "annotation", "{assembly}", "taxonomy",
             "orfs.{db}.taxonomy.tsv".format(db=config["taxonomy"]["database"])),
@@ -173,13 +182,3 @@ rule sum_to_taxa:
         opj(config["paths"]["results"], "annotation", "{assembly}", "taxonomy", "tax.{counts_type}.tsv")
     script:
         "../scripts/quantification_utils.py"
-
-rule sum_to_rgi:
-    input:
-        annot=opj(config["paths"]["results"], "annotation", "{assembly}", "rgi.out.txt"),
-        abund=opj(config["paths"]["results"], "annotation", "{assembly}", "gene_{counts_type}.tsv")
-    output:
-        opj(config["paths"]["results"], "annotation", "{assembly}", "rgi.{counts_type}.tsv")
-    script:
-        "../scripts/quantification_utils.py"
-

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -186,6 +186,20 @@ rule quantify_features:
             quantify {input.abund} {input.annot} {output[0]}
         """
 
+rule normalize:
+    input:
+        opj(config["paths"]["results"], "annotation", "{assembly}", "{db}.parsed.raw.tsv")
+    output:
+        opj(config["paths"]["results"], "annotation", "{assembly}", "{db}.parsed.{norm_method}.tsv")
+    log:
+        opj(config["paths"]["results"], "annotation", "{assembly}", "{db}.parsed.{norm_method}.log")
+    params:
+        method = "{norm_method}"
+    conda:
+        "../envs/normalize.yml"
+    script:
+        "../scripts/normalize.R"
+
 rule sum_to_taxa:
     input:
         tax=opj(config["paths"]["results"], "annotation", "{assembly}", "taxonomy",

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -1,8 +1,8 @@
 localrules:
     quantify,
     write_featurefile,
-    samtools_stats,
     aggregate_featurecount,
+    clean_featurecount,
     sum_to_taxa,
     quantify_features,
     sum_to_rgi
@@ -69,20 +69,6 @@ rule remove_mark_duplicates:
         mv {params.temp_sort_bam} {output[0]}
         mv {params.temp_sort_bam}.bai {output[1]}
         rm {params.temp_bam} {params.rehead_bam} {params.header}
-        """
-
-rule samtools_stats:
-    input:
-        opj(config["paths"]["results"], "assembly", "{assembly}",
-                "mapping", "{sample}_{unit}_{seq_type}"+POSTPROCESS+".bam")
-    output:
-        opj(config["paths"]["results"], "assembly", "{assembly}",
-                "mapping", "{sample}_{unit}_{seq_type}"+POSTPROCESS+".bam.stats")
-    conda:
-        "../envs/quantify.yml"
-    shell:
-        """
-        samtools stats {input} > {output}
         """
 
 ##### featurecounts #####

--- a/workflow/scripts/annotation_utils.py
+++ b/workflow/scripts/annotation_utils.py
@@ -3,6 +3,13 @@
 import pandas as pd
 
 
+def parse_rgi(sm):
+    annot = pd.read_csv(sm.input.txt, sep="\t", index_col=0)
+    annot = annot.loc[:, ["AMR Gene Family", "Resistance Mechanism"]]
+    annot.rename(index=lambda x: x.split(" ")[0], inplace=True)
+    annot.to_csv(sm.output.tsv, sep="\t", index=True)
+
+
 def parse_pfam(sm):
     annot = pd.read_csv(sm.input[0], comment="#", header=None, sep=" +",
                         usecols=[0, 5, 7, 14], engine="python",
@@ -28,7 +35,8 @@ def parse_pfam(sm):
 
 
 def main(sm):
-    toolbox = {"parse_pfam": parse_pfam}
+    toolbox = {"parse_pfam": parse_pfam,
+               "parse_rgi": parse_rgi}
     toolbox[sm.rule](sm)
 
 

--- a/workflow/scripts/annotation_utils.py
+++ b/workflow/scripts/annotation_utils.py
@@ -5,7 +5,8 @@ import pandas as pd
 
 def parse_rgi(sm):
     annot = pd.read_csv(sm.input.txt, sep="\t", index_col=0)
-    annot = annot.loc[:, ["AMR Gene Family", "Resistance Mechanism"]]
+    annot = annot.loc[:, ["Model_ID", "AMR Gene Family", "Resistance Mechanism"]]
+    annot.loc[:, "Model_ID"] = ["RGI_{}".format(x) for x in annot.Model_ID]
     annot.rename(index=lambda x: x.split(" ")[0], inplace=True)
     annot.to_csv(sm.output.tsv, sep="\t", index=True)
 

--- a/workflow/scripts/common.py
+++ b/workflow/scripts/common.py
@@ -628,10 +628,8 @@ def annotation_input(config, assemblies):
         # Add Resistance Gene Identifier output
         if config["annotation"]["rgi"]:
             input += expand(opj(config["paths"]["results"], "annotation", group,
-                                "rgi.{norm_method}.tsv"),
+                                "rgi.parsed.{norm_method}.tsv"),
                             norm_method=["counts", "TMM", "REL", "CSS"])
-            input.append(opj(config["paths"]["results"], "annotation", group,
-                             "rgi.out.txt"))
     return input
 
 

--- a/workflow/scripts/common.py
+++ b/workflow/scripts/common.py
@@ -613,12 +613,12 @@ def annotation_input(config, assemblies):
             input += expand(opj(config["paths"]["results"], "annotation", group,
                                 "{db}.parsed.{norm_method}.tsv"),
                             db=["enzymes", "pathways", "kos", "modules"],
-                            norm_method=["counts", "TMM", "REL", "CSS"])
+                            norm_method=["counts", "TMM", "RLE", "CSS"])
         # Add PFAM annotation
         if config["annotation"]["pfam"]:
             input += expand(opj(config["paths"]["results"], "annotation", group,
                                 "pfam.parsed.{norm_method}.tsv"),
-                            norm_method=["counts", "TMM", "REL", "CSS"])
+                            norm_method=["counts", "TMM", "RLE", "CSS"])
         # Add taxonomic annotation
         if config["annotation"]["taxonomy"]:
             input += expand(
@@ -629,7 +629,7 @@ def annotation_input(config, assemblies):
         if config["annotation"]["rgi"]:
             input += expand(opj(config["paths"]["results"], "annotation", group,
                                 "rgi.parsed.{norm_method}.tsv"),
-                            norm_method=["counts", "TMM", "REL", "CSS"])
+                            norm_method=["counts", "TMM", "RLE", "CSS"])
     return input
 
 

--- a/workflow/scripts/common.py
+++ b/workflow/scripts/common.py
@@ -611,22 +611,25 @@ def annotation_input(config, assemblies):
         # Add EGGNOG annotation
         if config["annotation"]["eggnog"]:
             input += expand(opj(config["paths"]["results"], "annotation", group,
-                                "{db}.parsed.{fc}.tsv"),
+                                "{db}.parsed.{norm_method}.tsv"),
                             db=["enzymes", "pathways", "kos", "modules"],
-                            fc=["raw", "tpm"])
+                            norm_method=["counts", "TMM", "REL", "CSS"])
         # Add PFAM annotation
         if config["annotation"]["pfam"]:
             input += expand(opj(config["paths"]["results"], "annotation", group,
-                                "pfam.parsed.{fc}.tsv"), fc=["tpm", "raw"])
+                                "pfam.parsed.{norm_method}.tsv"),
+                            norm_method=["counts", "TMM", "REL", "CSS"])
         # Add taxonomic annotation
         if config["annotation"]["taxonomy"]:
             input += expand(
                 opj(config["paths"]["results"], "annotation", group, "taxonomy",
-                    "tax.{fc}.tsv"), fc=["tpm", "raw"])
+                    "tax.{counts_type}.tsv"),
+                counts_type=["counts", "rpkm"])
         # Add Resistance Gene Identifier output
         if config["annotation"]["rgi"]:
             input += expand(opj(config["paths"]["results"], "annotation", group,
-                                "rgi.{fc}.tsv"), fc=["raw", "tpm"])
+                                "rgi.{norm_method}.tsv"),
+                            norm_method=["counts", "TMM", "REL", "CSS"])
             input.append(opj(config["paths"]["results"], "annotation", group,
                              "rgi.out.txt"))
     return input

--- a/workflow/scripts/normalize.R
+++ b/workflow/scripts/normalize.R
@@ -19,7 +19,9 @@ method <- snakemake@params$method
 # Read the counts
 x <- read.delim(snakemake@input[[1]], row.names = 1)
 # Remove unclassified
-x <- x[row.names(x)!="Unclassified", ]
+if ("Unclassified" %in% row.names(x)){
+    x <- x[row.names(x)!="Unclassified", ]
+}
 # Extract only numeric columns
 x_num <- num_cols(x)
 

--- a/workflow/scripts/normalize.R
+++ b/workflow/scripts/normalize.R
@@ -24,15 +24,25 @@ x <- x[row.names(x)!="Unclassified", ]
 x_num <- num_cols(x)
 
 if (method %in% c("TMM", "RLE")) {
-    library(edgeR, quietly = TRUE)
+    library(edgeR)
     # Create DGE
     obj <- DGEList(x_num)
     # Calculate norm factors
     obj <- calcNormFactors(obj, method = method)
     # Calculate cpms
     norm <- cpm(obj, normalized.lib.sizes = TRUE)
+} else if (method == "RPKM") {
+    library(edgeR)
+    # Extract gene length column
+    gene_length <- x_num$Length
+    x_num <- x_num[, colnames(x_num) != "Length"]
+    obj <- DGEList(x_num)
+    # Calculate norm factors
+    obj <- calcNormFactors(obj, method = "TMM")
+    # Calculate RPKM
+    norm <- rpkm(obj, normalized.lib.sizes = TRUE, gene.length = gene_length)
 } else {
-    library(metagenomeSeq, quietly = TRUE)
+    library(metagenomeSeq)
     obj <- newMRexperiment(x_num)
     norm <- MRcounts(obj, norm = TRUE)
 }

--- a/workflow/scripts/normalize.R
+++ b/workflow/scripts/normalize.R
@@ -1,0 +1,42 @@
+#!/usr/bin/env Rscript
+
+log <- file(snakemake@log[[1]], open="wt")
+sink(log)
+sink(log, type="message")
+
+num_cols <- function(x) {
+    x <- x[, unlist(lapply(x, is.numeric))]
+    x
+}
+
+str_cols <- function(x) {
+    x <- x[, unlist(lapply(x, is.character))]
+    x
+}
+
+method <- snakemake@params$method
+
+# Read the counts
+x <- read.delim(snakemake@input[[1]], row.names = 1)
+# Remove unclassified
+x <- x[row.names(x)!="Unclassified", ]
+# Extract only numeric columns
+x_num <- num_cols(x)
+
+if (method %in% c("TMM", "RLE")) {
+    library(edgeR, quietly = TRUE)
+    # Create DGE
+    obj <- DGEList(x_num)
+    # Calculate norm factors
+    obj <- calcNormFactors(obj, method = method)
+    # Calculate cpms
+    norm <- cpm(obj, normalized.lib.sizes = TRUE)
+} else {
+    library(metagenomeSeq, quietly = TRUE)
+    obj <- newMRexperiment(x_num)
+    norm <- MRcounts(obj, norm = TRUE)
+}
+
+norm <- cbind(str_cols(x), norm)
+
+write.table(x = norm, file = snakemake@output[[1]], quote = FALSE, sep="\t")

--- a/workflow/scripts/quantification_utils.py
+++ b/workflow/scripts/quantification_utils.py
@@ -126,6 +126,8 @@ def sum_to_taxa(sm):
     df = pd.read_csv(sm.input.tax, sep="\t", index_col=0, header=None,
                      names=header)
     abund_df = pd.read_csv(sm.input.abund, header=0, index_col=0, sep="\t")
+    # Remove length column
+    abund_df.drop("Length", axis=1, inplace=True, errors="ignore")
     taxa_abund = pd.merge(df, abund_df, right_index=True, left_index=True)
     taxa_abund_sum = taxa_abund.groupby(header[1:]).sum().reset_index()
     taxa_abund_sum.to_csv(sm.output[0], sep="\t", index=False)

--- a/workflow/scripts/quantification_utils.py
+++ b/workflow/scripts/quantification_utils.py
@@ -110,7 +110,7 @@ def count_features(sm):
     :param sm:
     :return:
     """
-    feature_sum = sum_to_features(sm.input.abundance, sm.input.parsed)
+    feature_sum = sum_to_features(sm.input.abund, sm.input.annot)
     feature_sum.to_csv(sm.output[0], sep="\t")
 
 def sum_to_taxa(sm):
@@ -133,32 +133,12 @@ def sum_to_taxa(sm):
     taxa_abund_sum.to_csv(sm.output[0], sep="\t", index=False)
 
 
-def sum_to_rgi(sm):
-    """
-    Takes Resistance gene identifier output and abundance info per orf and sums
-    values to gene family level
-
-    :param sm: snakemake object
-    :return:
-    """
-    annot = pd.read_csv(sm.input.annot, sep="\t", header=0, index_col=0,
-                        usecols=[0, 16])
-    # Rename index for annotations to remove text after whitespace
-    annot.rename(index=lambda x: x.split(" ")[0], inplace=True)
-    abund = pd.read_csv(sm.input.abund, sep="\t", header=0, index_col=0)
-    df = pd.merge(annot, abund, left_index=True, right_index=True)
-    # Sum to Gene family
-    dfsum = df.groupby("AMR Gene Family").sum()
-    dfsum.to_csv(sm.output[0], sep="\t", index=True, header=True)
-
-
 def main(sm):
     toolbox = {"write_featurefile": write_featurefile,
                "clean_featurecount": clean_featurecount,
                "aggregate_featurecount": aggregate_featurecount,
                "count_features": count_features,
-               "sum_to_taxa": sum_to_taxa,
-               "sum_to_rgi": sum_to_rgi}
+               "sum_to_taxa": sum_to_taxa}
 
     toolbox[sm.rule](sm)
 


### PR DESCRIPTION
This PR updates the way the workflow normalizes gene and feature counts. Support for TPM calculations (using custom functions) is removed and instead 3 normalization strategies are used after summing counts to features (PFAMs, eggNOG output and resistance genes (RGI)):

- Trimmed mean of M-values (TMM)
- Relative Log Expression (RLE)
- Cumulative sum scaling (CSS)

The first two are implemented via the `edgeR` package while the third is run via the `metagenomeSeq` package, both in R.

For taxonomic assignments RPKM values are calculated for all called genes using `edgeR` and these values are summed up to the lowest taxonomic rank used (species by default).