### PR TITLE
2.2-patch1

### DIFF
--- a/workflow/envs/plotting.yml
+++ b/workflow/envs/plotting.yml
@@ -4,6 +4,6 @@ channels:
   - defaults
 dependencies:
   - python=3.8.2
-  - seaborn=0.10.1
+  - seaborn=0.11.1
   - pandas=1.0.3
   - jupyter=1.0.0

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -294,7 +294,7 @@ rule emapper_homology_search:
         rm -rf {params.tmpdir}
         """
 
-if config["runOnUppMax"] == "yes":
+if config["runOnUppMax"]:
     rule emapper_annotate_hits_uppmax:
         """Copy EGGNOG db into memory before running annotations"""
         input:

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -636,6 +636,8 @@ rule barrnap:
                     lines=$(wc -l {params.outdir}/out | cut -f1 -d ' ')
                     if [ $lines -gt 1 ]; then
                         egrep -v "^#" {params.outdir}/out | sed "s/$/;genome=$g/g" >> {output}
+                    else
+                        touch {output}
                     fi
                 done
             rm {params.outdir}/out

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -438,7 +438,7 @@ rule checkm_coverage:
         opj(config["paths"]["results"], "binning", "{binner}", "{assembly}", "{l}", "checkm", "checkm_coverage.log")
     params:
         dir=lambda wildcards, input: os.path.dirname(input.tsv)
-    threads: 10
+    threads: 20
     resources:
         runtime=lambda wildcards, attempt: attempt**2*60
     conda:

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -633,7 +633,7 @@ rule barrnap:
                         k="arc"
                     fi
                     barrnap --kingdom $k {params.indir}/$g.fa > {params.outdir}/out 2>>{log}
-                    lines=$(wc -l {params.outdir}/out)
+                    lines=$(wc -l {params.outdir}/out | | cut -f1 -d ' ')
                     if [ $lines > 1 ]; then
                         egrep -v "^#" {params.outdir}/out | sed "s/$/;genome=$g/g" >> {output}
                     fi

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -591,7 +591,7 @@ rule aggregate_gtdbtk:
                 summary=opj(gtdb_dir, "gtdbtk.{}.summary.tsv".format(m))
                 if os.path.exists(summary):
                     summaries.append(summary)
-        df=concatenate(summaries)
+        df=concatenate(summaries, -3)
         df.to_csv(output.summary, sep="\t")
 
 ##### annotate bins #####

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -631,7 +631,7 @@ rule barrnap:
                     else
                         k="arc"
                     fi
-                    barrnap --kingdom $k --quiet {params.indir}/$g.fa | \
+                    barrnap --kingdom $k {params.indir}/$g.fa 2>>{log} | \
                         egrep -v "^#" | sed "s/$/;genome=$g/g" >> {output}
                 done
         fi

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -633,7 +633,7 @@ rule barrnap:
                         k="arc"
                     fi
                     barrnap --kingdom $k {params.indir}/$g.fa > {params.outdir}/out 2>>{log}
-                    lines=$(wc -l {params.outdir}/out | | cut -f1 -d ' ')
+                    lines=$(wc -l {params.outdir}/out | cut -f1 -d ' ')
                     if [ $lines > 1 ]; then
                         egrep -v "^#" {params.outdir}/out | sed "s/$/;genome=$g/g" >> {output}
                     fi

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -591,7 +591,7 @@ rule aggregate_gtdbtk:
                 summary=opj(gtdb_dir, "gtdbtk.{}.summary.tsv".format(m))
                 if os.path.exists(summary):
                     summaries.append(summary)
-        df=concatenate(summaries, -3)
+        df=concatenate(summaries, index=-3)
         df.to_csv(output.summary, sep="\t")
 
 ##### annotate bins #####
@@ -723,9 +723,9 @@ rule aggregate_bin_annot:
         trna=opj(config["paths"]["results"], "report", "bin_annotation", "tRNA.total.tsv"),
         rrna=opj(config["paths"]["results"], "report", "bin_annotation", "rRNA.types.tsv")
     run:
-        df=concatenate(input.trna)
+        df=concatenate(input.trna, index=-3)
         df.to_csv(output.trna, sep="\t", index=True)
-        df=concatenate(input.rrna)
+        df=concatenate(input.rrna, index=-3)
         df.to_csv(output.rrna, sep="\t", index=True)
 
 ##### genome clustering #####

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -634,7 +634,7 @@ rule barrnap:
                     fi
                     barrnap --kingdom $k {params.indir}/$g.fa > {params.outdir}/out 2>>{log}
                     lines=$(wc -l {params.outdir}/out | cut -f1 -d ' ')
-                    if [ $lines > 1 ]; then
+                    if [ $lines -gt 1 ]; then
                         egrep -v "^#" {params.outdir}/out | sed "s/$/;genome=$g/g" >> {output}
                     fi
                 done

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -429,9 +429,9 @@ rule checkm_coverage:
     input:
         tsv=opj(config["paths"]["results"], "binning", "{binner}", "{assembly}", "{l}", "summary_stats.tsv"),
         bam=get_all_files(samples, opj(config["paths"]["results"], "assembly",
-                                         "{assembly}", "mapping"), ".markdup.bam"),
+                                         "{assembly}", "mapping"), "{p}.bam".format(p=POSTPROCESS)),
         bai=get_all_files(samples, opj(config["paths"]["results"], "assembly",
-                                         "{assembly}", "mapping"), ".markdup.bam.bai")
+                                         "{assembly}", "mapping"), "{p}.bam.bai".format(p=POSTPROCESS))
     output:
         cov=temp(opj(config["paths"]["results"], "binning", "{binner}", "{assembly}", "{l}", "checkm", "coverage.tsv"))
     log:

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -611,7 +611,8 @@ rule barrnap:
         "../envs/barrnap.yml"
     params:
         indir=lambda wildcards, input: os.path.dirname(input.tsv),
-        gtdbtk_dir=lambda wildcards, input: os.path.dirname(input.gtdbtk)
+        gtdbtk_dir=lambda wildcards, input: os.path.dirname(input.gtdbtk),
+        outdir=lambda wildcards, output: os.path.dirname(output[0])
     resources:
         runtime=lambda wildcards, attempt: attempt**2*30
     threads: 1
@@ -631,9 +632,13 @@ rule barrnap:
                     else
                         k="arc"
                     fi
-                    barrnap --kingdom $k {params.indir}/$g.fa 2>>{log} | \
-                        egrep -v "^#" | sed "s/$/;genome=$g/g" >> {output}
+                    barrnap --kingdom $k {params.indir}/$g.fa > {params.outdir}/out 2>>{log}
+                    lines=$(wc -l {params.outdir}/out)
+                    if [ $lines > 1 ]; then
+                        egrep -v "^#" {params.outdir}/out | sed "s/$/;genome=$g/g" >> {output}
+                    fi
                 done
+            rm {params.outdir}/out
         fi
         """
 

--- a/workflow/scripts/binning_utils.py
+++ b/workflow/scripts/binning_utils.py
@@ -134,7 +134,7 @@ def remove_checkm_zerocols(sm):
     zero_cols = df_sum.loc[df_sum == 0].index
     cols_to_drop = []
     # find suffix of zero cols
-    for c in list(zero_cols) + ["Mapped reads"]:
+    for c in list(zero_cols):
         suffix = ".{}".format(c.split(".")[-1])
         if suffix == ".Mapped reads":
             suffix = ""

--- a/workflow/scripts/binning_utils.py
+++ b/workflow/scripts/binning_utils.py
@@ -174,7 +174,7 @@ def count_rrna(sm):
                          right_index=True)
     table = table.loc[:, ["5S_rRNA", "16S_rRNA", "23S_rRNA"]]
     table.index.name = "Bin_Id"
-    table.to_csv(sm.output, sep="\t", index=True)
+    table.to_csv(sm.output[0], sep="\t", index=True)
 
 
 def count_trna(sm):

--- a/workflow/scripts/binning_utils.py
+++ b/workflow/scripts/binning_utils.py
@@ -183,7 +183,7 @@ def count_trna(sm):
     :param sm:
     :return:
     """
-    df = pd.read_csv(sm.input, sep="\t")
+    df = pd.read_csv(sm.input[0], sep="\t")
     dfc = df.groupby(["tRNA_type", "Bin_Id"]).count().reset_index().loc[:,
           ["tRNA_type", "tRNA#", "Bin_Id"]]
     table = dfc.pivot_table(columns="tRNA_type", index="Bin_Id")[

--- a/workflow/scripts/binning_utils.py
+++ b/workflow/scripts/binning_utils.py
@@ -157,7 +157,7 @@ def count_rrna(sm):
     :param sm:
     :return:
     """
-    df = pd.read_csv(sm.input, sep="\t", usecols=[0, 2, 8], header=None,
+    df = pd.read_csv(sm.input[0], sep="\t", usecols=[0, 2, 8], header=None,
                      names=["contig", "type", "fields"])
     types = [x.split(";")[0].split("=")[-1] for x in df.fields]
     bins = [x.split(";")[-1].split("=")[-1] for x in df.fields]


### PR DESCRIPTION
- bugfixes for `barrnap` RNA prediction
- fixed a bug that forced use of MarkDuplicates with checkm profiling
- fixed a bug that removed first sample from checkm coverage